### PR TITLE
branch support

### DIFF
--- a/lib/Spine/ConfigSource/ISO9660.pm
+++ b/lib/Spine/ConfigSource/ISO9660.pm
@@ -58,7 +58,7 @@ sub new
     {
         my $section = $args{Config}->{ISO9660};
 
-        foreach my $item (qw(Destination URL Timeout Username Password Proxy))
+        foreach my $item (qw(Destination URL Timeout Username Password Proxy Branch))
         {
             if ( ( not exists($self->{$item})
                    or not defined($self->{$item}) )
@@ -293,6 +293,11 @@ sub check_for_update
     my $file = shift;
     my $check = "$self->{URL}?a=check&prev=$prev";
 
+    if ($self->{Branch})
+    {
+        $check .= "&branch=" . $self->{Branch}
+    }
+
     my $resp = $self->_http_request($check);
 
     my $version_data = undef;
@@ -348,6 +353,11 @@ sub retrieve
     my $file = "spine-config-$release.iso.gz";
     # Check to see if we have it cached locally first
     my $cached = $self->{_cache}->get($file);
+
+    if ($self->{Branch})
+    {
+        $retrieve .= "&branch=" . $self->{Branch}
+    }
 
     if ($cached)
     {

--- a/spine-mgmt.conf
+++ b/spine-mgmt.conf
@@ -14,6 +14,7 @@ Timeout = 5
 # Username = user
 # Password = pass
 # Proxy = proxy
+# Branch = branch
 
 [StandardPlugins]
 DISCOVERY/populate = DryRun SystemInfo


### PR DESCRIPTION
support for entity 'branches'.  the configball publisher can create 'balls
scrubbed of all entity data but one.  if one of these configballs exists,
setting Branch = <branch> will result in one of these 'clean' configballs
being pulled down